### PR TITLE
Remove references to --name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ If you saved this yaml as ``./pipelines/hoping-for-a-hotdog.yaml``, you can run
 
 .. code-block:: bash
 
-  ./pypyr --name hoping-for-a-hotdog --log 20
+  ./pypyr hoping-for-a-hotdog --log 20
 
 
 See a worked example for `pypyr slack here

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Requires the following context items:
 
 Text substitutions
 ------------------
-For both slackChannel and slackText you can use substitution tokens, or string
+For both slackChannel and slackText you can use substitution tokens, aka string
 interpolation. This substitutes anything between curly braces with the context
 value for that key. For example, if your context looked like this:
 
@@ -143,7 +143,7 @@ you want to post. You invite the bot in like you would a normal user.
 Ensure secrets stay secret
 ==========================
 Be safe! Don't hard-code your api token, don't check it into a public repo.
-Here are some api handling tokens from `slack <http://slackapi.github.io/python-slackclient/auth.html#handling-tokens>`__.
+Here are some tips for handling api tokens from `slack <http://slackapi.github.io/python-slackclient/auth.html#handling-tokens>`__.
 
 Do remember not to fling the api key around as a shell argument - it could
 very easily leak that way into logs or expose via a ``ps``. I generally use one

--- a/pypyrslack/version.py
+++ b/pypyrslack/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.0.2'
+__version__ = '0.1.0'
 
 
 def get_version():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.2
+current_version = 0.1.0
 
 [bdist_wheel]
 universal = 0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
 
         # Indicate who your project is intended for
         'Intended Audience :: Developers',


### PR DESCRIPTION
- pypyr cli now invokes as `pypyr pipe` rather than `pypyr --name pipe`
- fix some README grammar
- bump dev status to beta, like pypyr core
