### PR TITLE
fix typo in README for substitutions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,7 @@ If you saved this yaml as ``./pipelines/hoping-for-a-hotdog.yaml``, you can run
 
 .. code-block:: bash
 
-  ./pypyr hoping-for-a-hotdog --log 20
+  ./pypyr hoping-for-a-hotdog
 
 
 See a worked example for `pypyr slack here

--- a/README.rst
+++ b/README.rst
@@ -115,10 +115,11 @@ could look like:
         slackText: "whoops! :rage1:"
 
 If you saved this yaml as ``./pipelines/hoping-for-a-hotdog.yaml``, you can run
+from ./ the following:
 
 .. code-block:: bash
 
-  ./pypyr hoping-for-a-hotdog
+  pypyr hoping-for-a-hotdog
 
 
 See a worked example for `pypyr slack here

--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ value for that key. For example, if your context looked like this:
   arbitraryText: down the
   moreArbText: wild
   slackChannel: "#{arbitraryValue}"
-  slackText: "piping {arbitraryText} the valleys {moreArbText}"
+  slackText: "piping {arbitraryText} valleys {moreArbText}"
 
 This will result in sending a message to *#pypyrchannel* with text:
 


### PR DESCRIPTION
- Minor correction on README for string substitutions
- remove redundant --log 20 from
- fix relative path reference in README