### PR TITLE
Rename pypi from pypyr-slack to pypyrslack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,9 @@ pip
 ===
 .. code-block:: bash
 
-  # pip install --upgrade pypyr-slack
+  # pip install --upgrade pypyrslack
 
-pypyr-slack depends on pypyr-cli. The above ``pip`` will install it for you if
+pypyrslack depends on pypyr-cli. The above ``pip`` will install it for you if
 you don't have it already.
 
 Python version
@@ -230,7 +230,7 @@ https://www.345.systems/contact.
                 :alt: coverage status
                 :target: https://app.shippable.com/github/pypyr/pypyr-slack
 
-.. |pypi| image:: https://badge.fury.io/py/pypyr-slack.svg
+.. |pypi| image:: https://badge.fury.io/py/pypyrslack.svg
                 :alt: pypi version
-                :target: https://pypi.python.org/pypi/pypyr-slack/
+                :target: https://pypi.python.org/pypi/pypyrslack/
                 :align: bottom

--- a/ops/shippable-pypi-release.sh
+++ b/ops/shippable-pypi-release.sh
@@ -14,20 +14,20 @@ echo "New version is: ${NEW_VERSION}"
 TAG_NAME="v${NEW_VERSION}"
 
 # all done, clean-up
-pip uninstall -y pypyr-slack
+pip uninstall -y pypyrslack
 
 # Build wheel in dist/
 python setup.py bdist_wheel
 
 # Deploy wheel
-twine upload --repository-url ${PYPI_URL} --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD} dist/pypyr_slack-${NEW_VERSION}-py3-none-any.whl
+twine upload --repository-url ${PYPI_URL} --username ${PYPI_USERNAME} --password ${PYPI_PASSWORD} dist/pypyrslack-${NEW_VERSION}-py3-none-any.whl
 
 echo "----------Done with twine upload-------------------------------------"
 
 # smoke test
 echo "----------Deploy to pypi complete. Testing in new virtual env.-------"
 
-pip install pypyr-slack -q
+pip install pypyrslack -q
 # pypyr --v will return "pypyr x.y.z" - get everything after the space for the
 # bare version number.
 TEST_DEPLOY_VERSION=`python pypyrslack/version.py`

--- a/ops/shippable-tag-release.sh
+++ b/ops/shippable-tag-release.sh
@@ -14,7 +14,7 @@ echo "New version is: ${NEW_VERSION}"
 TAG_NAME="v${NEW_VERSION}"
 
 # all done, clean-up
-pip uninstall -y pypyr
+pip uninstall -y pypyrslack
 
 if [ $(git tag -l "${TAG_NAME}") ]; then
     echo "----------tag already exists.----------------------------------------"

--- a/pypyrslack/version.py
+++ b/pypyrslack/version.py
@@ -2,7 +2,7 @@
 
 import platform
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'
 
 
 def get_version():

--- a/pypyrslack/version.py
+++ b/pypyrslack/version.py
@@ -7,7 +7,7 @@ __version__ = '0.1.1'
 
 def get_version():
     """Returns package-name __version__ python python_version"""
-    return (f'pypyr-slack {__version__} '
+    return (f'pypyrslack {__version__} '
             f'python {platform.python_version()}')
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.2.0
 
 [bdist_wheel]
 universal = 0

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(
-    name='pypyr-slack',
+    name='pypyrslack',
 
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see

--- a/tests/unit/pypyrslack/version_test.py
+++ b/tests/unit/pypyrslack/version_test.py
@@ -5,6 +5,6 @@ import platform
 
 def test_get_version():
     actual = pypyrslack.version.get_version()
-    expected = (f'pypyr-slack {pypyrslack.version.__version__} '
+    expected = (f'pypyrslack {pypyrslack.version.__version__} '
                 f'python {platform.python_version()}')
     assert actual == expected, "version not returning correctly"


### PR DESCRIPTION
- Breaking change. Henceforth, use `pip install pypyrslack`, not `pip install pypyr-slack`