### PR TITLE
python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,24 +203,24 @@ Day-to-day testing
 
     pytest tests/unit/arb_test_file.py
 
+*****
+Help!
+*****
+Don't Panic! For help, community or talk, join the chat on |discord|!
+
 **********
 Contribute
 **********
+Developers
+==========
+For information on how to help with pypyr, run tests and coverage, please do
+check out the `contribution guide <https://github.com/pypyr/pypyr-cli/blob/master/CONTRIBUTING.rst>`_.
+
 Bugs
 ====
 Well, you know. No one's perfect. Feel free to `create an issue
 <https://github.com/pypyr/pypyr-slack/issues/new>`_.
 
-Contribute to the pypyr project
-===============================
-The usual jazz - create an issue, fork, code, test, PR. It might be an idea to
-discuss your idea via the Issues list first before you go off and write a
-huge amount of code - you never know, something might already be in the works,
-or maybe it's not quite right for this plug-in (you're still welcome to fork
-and go wild regardless, of course, it just mightn't get merged back in here).
-
-Get in touch anyway, would love to hear from you at
-https://www.345.systems/contact.
 
 .. |build-status| image:: https://api.shippable.com/projects/58efdfe19755e8070035afd9/badge?branch=master
                     :alt: build status
@@ -234,3 +234,5 @@ https://www.345.systems/contact.
                 :alt: pypi version
                 :target: https://pypi.python.org/pypi/pypyrslack/
                 :align: bottom
+
+.. |discord| replace:: `discord <https://discordapp.com/invite/8353JkB>`__

--- a/shippable.yaml
+++ b/shippable.yaml
@@ -2,6 +2,7 @@ language: python
 
 python:
  - "3.6"
+ - "3.7"
 
 build:
   ci:

--- a/tests/unit/pypyrslack/errors_test.py
+++ b/tests/unit/pypyrslack/errors_test.py
@@ -11,8 +11,7 @@ def test_base_error_raises():
     with pytest.raises(PypyrSlackError) as err_info:
         raise PypyrSlackError("this is error text right here")
 
-    assert repr(err_info.value) == ("Error('this is error text "
-                                    "right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_slack_send_error_raises():
@@ -20,8 +19,7 @@ def test_slack_send_error_raises():
     with pytest.raises(SlackSendError) as err_info:
         raise SlackSendError("this is error text right here")
 
-    assert repr(err_info.value) == ("SlackSendError('this is error "
-                                    "text right here',)")
+    assert str(err_info.value) == "this is error text right here"
 
 
 def test_slack_send_error_inheritance():

--- a/tests/unit/pypyrslack/steps/send_test.py
+++ b/tests/unit/pypyrslack/steps/send_test.py
@@ -61,7 +61,7 @@ def test_slack_error_raises(mock_client, mock_post):
     with pytest.raises(SlackSendError) as err_info:
         send.run_step(context)
 
-    assert repr(err_info.value) == ("SlackSendError('bang bang',)")
+    assert str(err_info.value) == "bang bang"
 
 
 def test_no_slack_token_raises():
@@ -71,10 +71,9 @@ def test_no_slack_token_raises():
                            'slackText': 'this is :boom: text'})
         send.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['slackToken'] "
-        "doesn't exist. It must exist for "
-        "pypyrslack.steps.send.\",)")
+    assert str(err_info.value) == (
+        "context['slackToken'] doesn't exist. It must exist for "
+        "pypyrslack.steps.send.")
 
 
 def test_no_slack_channel_raises():
@@ -84,10 +83,9 @@ def test_no_slack_channel_raises():
                            'slackText': 'this is :boom: text'})
         send.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['slackChannel'] "
-        "doesn't exist. It must exist for "
-        "pypyrslack.steps.send.\",)")
+    assert str(err_info.value) == (
+        "context['slackChannel'] doesn't exist. It must exist for "
+        "pypyrslack.steps.send.")
 
 
 def test_no_slack_text_raises():
@@ -97,10 +95,9 @@ def test_no_slack_text_raises():
                            'slackChannel': '#blah'})
         send.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyNotInContextError(\"context['slackText'] "
-        "doesn't exist. It must exist for "
-        "pypyrslack.steps.send.\",)")
+    assert str(err_info.value) == (
+        "context['slackText'] doesn't exist. It must exist for "
+        "pypyrslack.steps.send.")
 
 
 def test_slack_token_no_value_raises():
@@ -112,9 +109,8 @@ def test_slack_token_no_value_raises():
             'slackText': 'this is :boom: text'})
         send.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['slackToken'] "
-        "must have a value for pypyrslack.steps.send.\",)")
+    assert str(err_info.value) == (
+        "context['slackToken'] must have a value for pypyrslack.steps.send.")
 
 
 def test_slack_channel_no_value_raises():
@@ -126,6 +122,5 @@ def test_slack_channel_no_value_raises():
             'slackText': 'this is :boom: text'})
         send.run_step(context)
 
-    assert repr(err_info.value) == (
-        "KeyInContextHasNoValueError(\"context['slackChannel'] "
-        "must have a value for pypyrslack.steps.send.\",)")
+    assert str(err_info.value) == (
+        "context['slackChannel'] must have a value for pypyrslack.steps.send.")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py36,py37
 skipsdist = false
 
 [testenv:dev]
@@ -18,7 +18,7 @@ deps =
         pygments
         pytest
 commands =
-        # pip install -e ../pypyr-cli
+        pypyr --v
         # check-manifest --ignore tox.ini,tests*
         python setup.py check -m -r -s
         flake8 .


### PR DESCRIPTION
- make unit tests compatible with py 3.7. This is really just one change because of this https://bugs.python.org/issue30399 In a nutshell, repr() on Exceptions used to return an extra comma at the end in <py3.7, it doesn't anymore. 
- ci will run both 3.7 and 3.7 unit tests
- README updates with contributing guide