### PR TITLE
bare version number

### DIFF
--- a/ops/build.yaml
+++ b/ops/build.yaml
@@ -119,7 +119,7 @@ get_version:
         version_module = importlib.import_module(context['version_module_name'])
         if context.get('is_version_module_loaded'): 
           importlib.reload(version_module)
-        context['version'] = f'v{version_module.__version__}'
+        context['version'] = f'{version_module.__version__}'
         context['is_version_module_loaded'] = True
   - name: pypyr.steps.echo
     in:

--- a/ops/tag.yaml
+++ b/ops/tag.yaml
@@ -21,16 +21,16 @@ steps:
   - name: pypyr.steps.cmd
     in:
       cmd:
-        run: git tag -l "{version}"
+        run: git tag -l "v{version}"
         save: True
   - name: pypyr.steps.stopstepgroup
     description: --> check if tag already exists
-    run: !py cmdOut['stdout'].rstrip('\r\n') == version
+    run: !py cmdOut['stdout'].rstrip('\r\n') == f'v{version}'
   - name: pypyr.steps.cmd
     comment: tag current HEAD
     description: --> create new tag for release
     in:
-      cmd: git tag "{version}"
+      cmd: git tag "v{version}"
   - name: pypyr.steps.call
     comment: set git info only on ci, not local dev.
     run: '{isCi}'


### PR DESCRIPTION
- version number for pypi should not have v in front of it. GitHub tags do, however.