### PR TITLE
py 3.9 on CI build. remove ops/tag strip check

### DIFF
--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -17,7 +17,7 @@ jobs:
       # You can use PyPy versions in python-version.
       # For example, pypy2 and pypy3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/ops/tag.yaml
+++ b/ops/tag.yaml
@@ -25,7 +25,7 @@ steps:
         save: True
   - name: pypyr.steps.stopstepgroup
     description: --> check if tag already exists
-    run: !py cmdOut['stdout'].rstrip('\r\n') == f'v{version}'
+    run: !py cmdOut['stdout'] == f'v{version}'
   - name: pypyr.steps.cmd
     comment: tag current HEAD
     description: --> create new tag for release


### PR DESCRIPTION
 - ops/tag strip happens in `pypyr.steps.cmd` as of pypyr 4.2.0